### PR TITLE
change npm script debug command for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Boilerplate Code for Node Projects.
 
 * ``yarn debug`` or ``npm run debug`` to work in development mode.
 * ``npm run build`` and ``npm run start`` to build and start production server.
+* in Windows change  to  ``"serve-inspect": "set NODE_ENV=dev nodemon --inspect dist/server.js"``,
+* run npm run debug as Administrator in cmd
 
 ## Branches
 


### PR DESCRIPTION
On Windows the env values don't set properly and also it needs admin privileges for debug to run